### PR TITLE
Feature/issue-2/handling-market-hours

### DIFF
--- a/amd_stock_tracking.csv
+++ b/amd_stock_tracking.csv
@@ -1,2 +1,3 @@
 date,starting_price,ending_price,daily_change_pct,targets_reached
 2024-10-04,166.53,170.9,2.62,"1.2, 1.5, 2.2"
+2024-10-25,155.31,156.23,0.59,None


### PR DESCRIPTION
Adding a feature to handle market hours.

- Define market hours:
The U.S. stock market (where AMD is traded) is typically open from 9:30 AM to 4:00 PM Eastern Time (ET), Monday through Friday, excluding holidays.

- Create a function to check if it's within market hours:
This function should: a. Get the current time in Eastern Time. b. Check if it's a weekday. c. Check if the current time is between 9:30 AM and 4:00 PM ET. d. (Optional for future improvement) Check for market holidays.
Using is_market_open(self): method.

- Modify the fetch_daily_data method:
Before making the API call, check if it's within market hours.
If it's not within market hours, we fetch the most recent available data instead.

- Handle potential data gaps:
If the market was closed (e.g., on weekends or holidays (future implementation)), we want to fetch data for the last available trading day.
